### PR TITLE
Fix skipping root view when menu is cached

### DIFF
--- a/source/HomeAssistantApp.mc
+++ b/source/HomeAssistantApp.mc
@@ -130,6 +130,9 @@ class HomeAssistantApp extends Application.AppBase {
                     ErrorView.show(WatchUi.loadResource($.Rez.Strings.NoJson) as Lang.String);
                 } else {
                     buildMenu(data);
+                    if (Settings.getIsWidgetStartNoTap()){
+                        pushHomeAssistantMenuView();
+                    }
                 }
                 break;
 
@@ -141,7 +144,7 @@ class HomeAssistantApp extends Application.AppBase {
         WatchUi.requestUpdate();
     }
 
-    function fetchMenuConfig(){
+    function fetchMenuConfig() as Void{
         if (Settings.getConfigUrl().equals("")) {
             mMenuStatus = WatchUi.loadResource($.Rez.Strings.Unconfigured) as Lang.String;
             WatchUi.requestUpdate();
@@ -183,12 +186,6 @@ class HomeAssistantApp extends Application.AppBase {
     private function buildMenu(menu as Lang.Dictionary) {
         mHaMenu = new HomeAssistantView(menu, null);
         mQuitTimer.begin();
-        if (Settings.getIsWidgetStartNoTap()) {
-            // As soon as the menu has been fetched start show the menu of items.
-            // This behaviour is inconsistent with the standard Garmin User Interface, but has been
-            // requested by users so has been made the non-default option.
-            pushHomeAssistantMenuView();
-        }
         mItemsToUpdate = mHaMenu.getItemsToUpdate();
         // Start the continuous update process that continues for as long as the application is running.
         // The chain of functions from 'updateNextMenuItem()' calls 'updateNextMenuItem()' on completion.

--- a/source/RootView.mc
+++ b/source/RootView.mc
@@ -37,15 +37,16 @@ class RootView extends ScalableView {
     // view a swipe to left / "back button" press is done.
 
     private static const scMidSep = 10; // Middle Separator "text:_text" in pixels
-    private var mApp        as HomeAssistantApp;
-    private var mTitle      as WatchUi.Text or Null;
-    private var mApiText    as WatchUi.Text or Null;
-    private var mApiStatus  as WatchUi.Text or Null;
-    private var mMenuText   as WatchUi.Text or Null;
-    private var mMenuStatus as WatchUi.Text or Null;
-    private var mMemText    as WatchUi.Text or Null;
-    private var mMemStatus  as WatchUi.Text or Null;
-    private var mAntiAlias  as Lang.Boolean = false;
+    private var mApp             as HomeAssistantApp;
+    private var mTitle           as WatchUi.Text or Null;
+    private var mApiText         as WatchUi.Text or Null;
+    private var mApiStatus       as WatchUi.Text or Null;
+    private var mMenuText        as WatchUi.Text or Null;
+    private var mMenuStatus      as WatchUi.Text or Null;
+    private var mMemText         as WatchUi.Text or Null;
+    private var mMemStatus       as WatchUi.Text or Null;
+    private var mAntiAlias       as Lang.Boolean = false;
+    private var mInitialShowing  as Lang.Boolean = true;
 
     function initialize(app as HomeAssistantApp) {
         ScalableView.initialize();
@@ -148,7 +149,17 @@ class RootView extends ScalableView {
     }
 
     function onShow() as Void {
-        WatchUi.requestUpdate();
+        if (mInitialShowing){
+            mInitialShowing=false;
+            
+            if (mApp.isHomeAssistantMenuLoaded() && Settings.getIsWidgetStartNoTap()){
+                mApp.pushHomeAssistantMenuView();
+            } else {
+                WatchUi.requestUpdate();
+            }
+        } else {
+            WatchUi.requestUpdate();
+        }
     }
 }
 

--- a/source/RootView.mc
+++ b/source/RootView.mc
@@ -149,10 +149,9 @@ class RootView extends ScalableView {
     }
 
     function onShow() as Void {
-        if (mInitialShowing){
-            mInitialShowing=false;
-
-            if (mApp.isHomeAssistantMenuLoaded() && Settings.getIsWidgetStartNoTap()){
+        if (mInitialShowing) {
+            mInitialShowing = false;
+            if (mApp.isHomeAssistantMenuLoaded() && Settings.getIsWidgetStartNoTap()) {
                 mApp.pushHomeAssistantMenuView();
             } else {
                 WatchUi.requestUpdate();

--- a/source/RootView.mc
+++ b/source/RootView.mc
@@ -151,7 +151,7 @@ class RootView extends ScalableView {
     function onShow() as Void {
         if (mInitialShowing){
             mInitialShowing=false;
-            
+
             if (mApp.isHomeAssistantMenuLoaded() && Settings.getIsWidgetStartNoTap()){
                 mApp.pushHomeAssistantMenuView();
             } else {

--- a/source/Settings.mc
+++ b/source/Settings.mc
@@ -36,6 +36,9 @@ class Settings {
     private static var mAppTimeout            as Lang.Number  = 0;  // seconds
     private static var mConfirmTimeout        as Lang.Number  = 3;  // seconds
     private static var mMenuAlignment         as Lang.Number  = WatchUi.MenuItem.MENU_ITEM_LABEL_ALIGN_LEFT;
+    // As soon as the menu has been fetched start show the menu of items.
+    // This behaviour is inconsistent with the standard Garmin User Interface, but has been
+    // requested by users so has been made the non-default option.
     private static var mIsWidgetStartNoTap    as Lang.Boolean = false;
     private static var mIsBatteryLevelEnabled as Lang.Boolean = false;
     private static var mBatteryRefreshRate    as Lang.Number  = 15; // minutes


### PR DESCRIPTION
It is fixed.

I really wished that Menu2 Views could be used as root-view in Widgets... would make things so much easier. But yeah, that would break Garmins Widget UI and UX.. .