### PR TITLE
22 activity completed background update

### DIFF
--- a/source/BackgroundServiceDelegate.mc
+++ b/source/BackgroundServiceDelegate.mc
@@ -1,13 +1,13 @@
 //-----------------------------------------------------------------------------------
 //
 // Distributed under MIT Licence
-//   See https://github.com/house-of-abbey/GarminHomeAssistant/blob/main/LICENSE.
+//   See https://github.com/house-of-abbey/GarminHomeAssistantWidget/blob/main/LICENSE.
 //
 //-----------------------------------------------------------------------------------
 //
 // GarminHomeAssistant is a Garmin IQ application written in Monkey C and routinely
 // tested on a Venu 2 device. The source code is provided at:
-//            https://github.com/house-of-abbey/GarminHomeAssistant.
+//            https://github.com/house-of-abbey/GarminHomeAssistantWidget.
 //
 // P A Abbey & J D Abbey & Someone0nEarth, 31 October 2023
 //

--- a/source/BackgroundServiceDelegate.mc
+++ b/source/BackgroundServiceDelegate.mc
@@ -13,7 +13,8 @@
 //
 // Description:
 //
-// Light or switch toggle button that calls the API to maintain the up to date state.
+// The background service delegate currently just reports the Garmin watch's battery
+// level.
 //
 //-----------------------------------------------------------------------------------
 

--- a/source/BackgroundServiceDelegate.mc
+++ b/source/BackgroundServiceDelegate.mc
@@ -5,8 +5,7 @@
 //
 //-----------------------------------------------------------------------------------
 //
-// GarminHomeAssistant is a Garmin IQ application written in Monkey C and routinely
-// tested on a Venu 2 device. The source code is provided at:
+// GarminHomeAssistantWidget is a Garmin IQ widget written in Monkey C. The source code is provided at:
 //            https://github.com/house-of-abbey/GarminHomeAssistantWidget.
 //
 // P A Abbey & J D Abbey & Someone0nEarth, 31 October 2023
@@ -14,8 +13,7 @@
 //
 // Description:
 //
-// The background service delegate currently just reports the Garmin watch's battery
-// level.
+// Light or switch toggle button that calls the API to maintain the up to date state.
 //
 //-----------------------------------------------------------------------------------
 

--- a/source/BackgroundServiceDelegate.mc
+++ b/source/BackgroundServiceDelegate.mc
@@ -1,12 +1,13 @@
 //-----------------------------------------------------------------------------------
 //
 // Distributed under MIT Licence
-//   See https://github.com/house-of-abbey/GarminHomeAssistantWidget/blob/main/LICENSE.
+//   See https://github.com/house-of-abbey/GarminHomeAssistant/blob/main/LICENSE.
 //
 //-----------------------------------------------------------------------------------
 //
-// GarminHomeAssistantWidget is a Garmin IQ widget written in Monkey C. The source code is provided at:
-//            https://github.com/house-of-abbey/GarminHomeAssistantWidget.
+// GarminHomeAssistant is a Garmin IQ application written in Monkey C and routinely
+// tested on a Venu 2 device. The source code is provided at:
+//            https://github.com/house-of-abbey/GarminHomeAssistant.
 //
 // P A Abbey & J D Abbey & Someone0nEarth, 31 October 2023
 //
@@ -22,6 +23,7 @@ using Toybox.Lang;
 using Toybox.Application.Properties;
 using Toybox.Background;
 using Toybox.System;
+using Toybox.Activity;
 
 (:background)
 class BackgroundServiceDelegate extends System.ServiceDelegate {
@@ -36,99 +38,81 @@ class BackgroundServiceDelegate extends System.ServiceDelegate {
         Background.exit(null);
     }
 
+    function onActivityCompleted(activity as { :sport as Activity.Sport, :subSport as Activity.SubSport }) as Void {
+        if (!System.getDeviceSettings().phoneConnected) {
+            // System.println("BackgroundServiceDelegate onActivityCompleted(): No Phone connection, skipping API call.");
+        } else if (!System.getDeviceSettings().connectionAvailable) {
+            // System.println("BackgroundServiceDelegate onActivityCompleted(): No Internet connection, skipping API call.");
+        } else {
+            // Ensure we're logging completion, i.e. ignore 'activity' parameter
+            // System.println("BackgroundServiceDelegate onActivityCompleted(): Event triggered");
+            doUpdate(-1, -1);
+        }
+    }
+
     function onTemporalEvent() as Void {
         if (!System.getDeviceSettings().phoneConnected) {
             // System.println("BackgroundServiceDelegate onTemporalEvent(): No Phone connection, skipping API call.");
         } else if (!System.getDeviceSettings().connectionAvailable) {
             // System.println("BackgroundServiceDelegate onTemporalEvent(): No Internet connection, skipping API call.");
         } else {
-            // System.println("BackgroundServiceDelegate onTemporalEvent(): Making API call.");
-            var position = Position.getInfo();
-            // System.println("BackgroundServiceDelegate onTemporalEvent(): gps: " + position.position.toDegrees());
-            // System.println("BackgroundServiceDelegate onTemporalEvent(): speed: " + position.speed);
-            // System.println("BackgroundServiceDelegate onTemporalEvent(): course: " + position.heading + "rad (" + (position.heading * 180 / Math.PI) + "°)");
-            // System.println("BackgroundServiceDelegate onTemporalEvent(): altitude: " + position.altitude);
-            // System.println("BackgroundServiceDelegate onTemporalEvent(): battery: " + System.getSystemStats().battery);
-            // System.println("BackgroundServiceDelegate onTemporalEvent(): charging: " + System.getSystemStats().charging);
-            // System.println("BackgroundServiceDelegate onTemporalEvent(): activity: " + Activity.getProfileInfo().name);
-
-            // Don't use Settings.* here as the object lasts < 30 secs and is recreated each time the background service is run
-
-            if (position.accuracy != Position.QUALITY_NOT_AVAILABLE && position.accuracy != Position.QUALITY_LAST_KNOWN) {
-                var accuracy = 0;
-                switch (position.accuracy) {
-                    case Position.QUALITY_POOR:
-                        accuracy = 500;
-                        break;
-                    case Position.QUALITY_USABLE:
-                        accuracy = 100;
-                        break;
-                    case Position.QUALITY_GOOD:
-                        accuracy = 10;
-                        break;
-                }
-                Communications.makeWebRequest(
-                    (Properties.getValue("api_url") as Lang.String) + "/webhook/" + (Properties.getValue("webhook_id") as Lang.String),
-                    {
-                        "type" => "update_location",
-                        "data" => {
-                            "gps"          => position.position.toDegrees(),
-                            "gps_accuracy" => accuracy,
-                            "speed"        => Math.round(position.speed),
-                            "course"       => Math.round(position.heading * 180 / Math.PI),
-                            "altitude"     => Math.round(position.altitude),
-                        }
-                    },
-                    {
-                        :method       => Communications.HTTP_REQUEST_METHOD_POST,
-                        :headers      => {
-                            "Content-Type" => Communications.REQUEST_CONTENT_TYPE_JSON
-                        },
-                        :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON
-                    },
-                    method(:onReturnBatteryUpdate)
-                );
-            }
-            var data = [
-                {
-                    "state"     => System.getSystemStats().battery,
-                    "type"      => "sensor",
-                    "unique_id" => "battery_level"
-                },
-                {
-                    "state"     => System.getSystemStats().charging,
-                    "type"      => "binary_sensor",
-                    "unique_id" => "battery_is_charging"
-                }
-            ];
+            var activity     = null;
+            var sub_activity = null;
             if ((Activity has :getActivityInfo) and (Activity has :getProfileInfo)) {
-                var activity     = Activity.getProfileInfo().sport;
-                var sub_activity = Activity.getProfileInfo().subSport;
+                activity     = Activity.getProfileInfo().sport;
+                sub_activity = Activity.getProfileInfo().subSport;
                 // We need to check if we are actually tracking any activity as the enumerated type does not include "No Sport".
                 if ((Activity.getActivityInfo() != null) and
                     ((Activity.getActivityInfo().elapsedTime == null) or
-                     (Activity.getActivityInfo().elapsedTime == 0))) {
+                        (Activity.getActivityInfo().elapsedTime == 0))) {
                     // Indicate no activity with -1, not part of Garmin's activity codes.
                     // https://developer.garmin.com/connect-iq/api-docs/Toybox/Activity.html#Sport-module
                     activity     = -1;
                     sub_activity = -1;
                 }
-                data.add({
-                    "state"     => activity,
-                    "type"      => "sensor",
-                    "unique_id" => "activity"
-                });
-                data.add({
-                    "state"     => sub_activity,
-                    "type"      => "sensor",
-                    "unique_id" => "sub_activity"
-                });
+            }
+            // System.println("BackgroundServiceDelegate onTemporalEvent(): Event triggered, activity = " + activity + " sub_activity = " + sub_activity);
+            doUpdate(activity, sub_activity);
+        }
+    }
+
+    private function doUpdate(activity as Lang.Number or Null, sub_activity as Lang.Number or Null) {
+        // System.println("BackgroundServiceDelegate onTemporalEvent(): Making API call.");
+        var position = Position.getInfo();
+        // System.println("BackgroundServiceDelegate onTemporalEvent(): gps: " + position.position.toDegrees());
+        // System.println("BackgroundServiceDelegate onTemporalEvent(): speed: " + position.speed);
+        // System.println("BackgroundServiceDelegate onTemporalEvent(): course: " + position.heading + "rad (" + (position.heading * 180 / Math.PI) + "°)");
+        // System.println("BackgroundServiceDelegate onTemporalEvent(): altitude: " + position.altitude);
+        // System.println("BackgroundServiceDelegate onTemporalEvent(): battery: " + System.getSystemStats().battery);
+        // System.println("BackgroundServiceDelegate onTemporalEvent(): charging: " + System.getSystemStats().charging);
+        // System.println("BackgroundServiceDelegate onTemporalEvent(): activity: " + Activity.getProfileInfo().name);
+
+        // Don't use Settings.* here as the object lasts < 30 secs and is recreated each time the background service is run
+
+        if (position.accuracy != Position.QUALITY_NOT_AVAILABLE && position.accuracy != Position.QUALITY_LAST_KNOWN) {
+            var accuracy = 0;
+            switch (position.accuracy) {
+                case Position.QUALITY_POOR:
+                    accuracy = 500;
+                    break;
+                case Position.QUALITY_USABLE:
+                    accuracy = 100;
+                    break;
+                case Position.QUALITY_GOOD:
+                    accuracy = 10;
+                    break;
             }
             Communications.makeWebRequest(
                 (Properties.getValue("api_url") as Lang.String) + "/webhook/" + (Properties.getValue("webhook_id") as Lang.String),
                 {
-                    "type" => "update_sensor_states",
-                    "data" => data
+                    "type" => "update_location",
+                    "data" => {
+                        "gps"          => position.position.toDegrees(),
+                        "gps_accuracy" => accuracy,
+                        "speed"        => Math.round(position.speed),
+                        "course"       => Math.round(position.heading * 180 / Math.PI),
+                        "altitude"     => Math.round(position.altitude),
+                    }
                 },
                 {
                     :method       => Communications.HTTP_REQUEST_METHOD_POST,
@@ -140,6 +124,47 @@ class BackgroundServiceDelegate extends System.ServiceDelegate {
                 method(:onReturnBatteryUpdate)
             );
         }
+        var data = [
+            {
+                "state"     => System.getSystemStats().battery,
+                "type"      => "sensor",
+                "unique_id" => "battery_level"
+            },
+            {
+                "state"     => System.getSystemStats().charging,
+                "type"      => "binary_sensor",
+                "unique_id" => "battery_is_charging"
+            }
+        ];
+        if (activity != null) {
+            data.add({
+                "state"     => activity,
+                "type"      => "sensor",
+                "unique_id" => "activity"
+            });
+        }
+        if (sub_activity != null) {
+            data.add({
+                "state"     => sub_activity,
+                "type"      => "sensor",
+                "unique_id" => "sub_activity"
+            });
+        }
+        Communications.makeWebRequest(
+            (Properties.getValue("api_url") as Lang.String) + "/webhook/" + (Properties.getValue("webhook_id") as Lang.String),
+            {
+                "type" => "update_sensor_states",
+                "data" => data
+            },
+            {
+                :method       => Communications.HTTP_REQUEST_METHOD_POST,
+                :headers      => {
+                    "Content-Type" => Communications.REQUEST_CONTENT_TYPE_JSON
+                },
+                :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON
+            },
+            method(:onReturnBatteryUpdate)
+        );
     }
 
 }

--- a/source/Settings.mc
+++ b/source/Settings.mc
@@ -91,9 +91,11 @@ class Settings {
                 if ((Background.getTemporalEventRegisteredTime() == null) or
                     (Background.getTemporalEventRegisteredTime() != (mBatteryRefreshRate * 60))) {
                     Background.registerForTemporalEvent(new Time.Duration(mBatteryRefreshRate * 60)); // Convert to seconds
+                    Background.registerForActivityCompletedEvent();
                 }
             } else if (Background.getTemporalEventRegisteredTime() != null) {
                 Background.deleteTemporalEvent();
+                Background.registerForActivityCompletedEvent();
             }
         } else {
             // Explicitly disable the background event which persists when the application closes.
@@ -173,6 +175,7 @@ class Settings {
         Properties.setValue("enable_battery_level", mIsSensorsLevelEnabled);
         if (mHasService and (Background.getTemporalEventRegisteredTime() != null)) {
             Background.deleteTemporalEvent();
+            Background.registerForActivityCompletedEvent();
         }
     }
 }


### PR DESCRIPTION
Adding this does not appear to cause significant additional memory usage and hence I offer it up. @Someone0nEarth please can you decide if this is worth putting in the Widget? It does however require another beta test.

1. Load on your watch
2. Check the settings will start the background service
3. Start the app to get the background service running
4. Start an activity and optionally wait for HA to receive some telemetry updates
5. Stop an activity and verify there was an immediate end of activity update to HA with value `-1`.